### PR TITLE
fix: adding formatter for markdown style links

### DIFF
--- a/composables/response-formatter.ts
+++ b/composables/response-formatter.ts
@@ -30,31 +30,30 @@ export const useResponseFormat = () => {
     const linkRegex = /\[(.*?)\]\((.*?)\)/g;
 
     const lines = textToFormat.split('\n');
-    let fortmattedLines;
-    fortmattedLines = lines.map((line) => {
+    let formattedLines;
+    formattedLines = lines.map((line) => {
       return line.replace(boldRegex, (_, boldType1, boldType2) => {
         const boldText = boldType1 || boldType2;
         return `<strong>${boldText}</strong>`;
       });
     });
-    fortmattedLines = fortmattedLines.map((line) => {
+    formattedLines = formattedLines.map((line) => {
       return line.replace(titleRegex, (_, hashes, titleText) => {
         const titleLevel = hashes.length;
         return `<h${titleLevel}>${titleText}</h${titleLevel}>`;
       });
     });
-    fortmattedLines = fortmattedLines.map((line) => {
+    formattedLines = formattedLines.map((line) => {
       return line.replace(codeRegex, (_, code) => {
         return `<code>${code}</code>`;
       });
     });
-    fortmattedLines = fortmattedLines.map((line) => {
+    formattedLines = formattedLines.map((line) => {
       return line.replace(linkRegex, (_, url, link) => {
-        console.log(url, link);
         return `<a href="${url}" target="_blank" rel="noopener">${link}</a>`;
       });
     });
-    return fortmattedLines.join('<br />');
+    return formattedLines.join('<br />');
   };
 
   return {

--- a/composables/response-formatter.ts
+++ b/composables/response-formatter.ts
@@ -51,7 +51,7 @@ export const useResponseFormat = () => {
     fortmattedLines = fortmattedLines.map((line) => {
       return line.replace(linkRegex, (_, url, link) => {
         console.log(url, link);
-        return `<a href="${url}" class="text-cyan-400 underline">${link}</a>`;
+        return `<a href="${url}" target="_blank" rel="noopener">${link}</a>`;
       });
     });
     return fortmattedLines.join('<br />');

--- a/composables/response-formatter.ts
+++ b/composables/response-formatter.ts
@@ -52,8 +52,8 @@ export const useResponseFormat = () => {
       return line.replace(linkRegex, (_, url, link) => {
         console.log(url, link);
         return `<a href="${url}" class="text-cyan-400 underline">${link}</a>`;
-      })
-    })
+      });
+    });
     return fortmattedLines.join('<br />');
   };
 

--- a/composables/response-formatter.ts
+++ b/composables/response-formatter.ts
@@ -26,6 +26,9 @@ export const useResponseFormat = () => {
     //Regex for code (`...`)
     const codeRegex = /`([^`]*)`/g;
 
+    //Regex for Links
+    const linkRegex = /\[(.*?)\]\((.*?)\)/g;
+
     const lines = textToFormat.split('\n');
     let fortmattedLines;
     fortmattedLines = lines.map((line) => {
@@ -45,6 +48,12 @@ export const useResponseFormat = () => {
         return `<code>${code}</code>`;
       });
     });
+    fortmattedLines = fortmattedLines.map((line) => {
+      return line.replace(linkRegex, (_, url, link) => {
+        console.log(url, link);
+        return `<a href="${url}" class="text-cyan-400 underline">${link}</a>`;
+      })
+    })
     return fortmattedLines.join('<br />');
   };
 


### PR DESCRIPTION
Adds to the formatter a convertion from Markdown links into HTML <a> tags. Example:
`[www.example.com](example)`  becomes `<a href="www.example.com">example</a>`