### PR TITLE
fix: expose variable to show documents icon on last message

### DIFF
--- a/components/ChatZone.vue
+++ b/components/ChatZone.vue
@@ -141,6 +141,7 @@ const showResponseMenu = ref(true);
 
 let collectionName = '';
 const responseFormat = ref('text');
+const showLastMsgDocs = computed(() => hovered.value === dialog.value.length - 1 && canSeeDocs.value);
 
 onBeforeMount(async () => {
   if (props.startMessage) {
@@ -367,6 +368,7 @@ defineExpose({
   refreshChat,
   getResponseDocs,
   updateFeedbackThumbs,
+  showLastMsgDocs,
 });
 
 const openFeedback = (item: any, evaluation: boolean) => {


### PR DESCRIPTION
Exposes the variable `showLastMsgDocs` in order to show documents only on last response and if they are available