### PR TITLE
Switch to 'conversation' mode if no collection is present

### DIFF
--- a/components/ChatZone.vue
+++ b/components/ChatZone.vue
@@ -234,7 +234,7 @@ const streamingFetchRequest = async () => {
     },
     body: JSON.stringify({
       question,
-      collection: collectionName,
+      ...(collectionName.length > 0 ? { collection: collectionName } : {}),
       mode: collectionName ? 'rag' : 'conversation',
       source_docs: collectionName ? true : false,
       streaming: true,


### PR DESCRIPTION
This PR updates the `/chat` API behavior by switching to `"mode": "conversation"` when no collection is provided to the ChatZone component.