### PR TITLE
Adding config as props and to /chat body

### DIFF
--- a/components/ChatZone.vue
+++ b/components/ChatZone.vue
@@ -103,6 +103,7 @@ const props = defineProps({
   userNick: { type: String, default: 'YOU' },
   botName: { type: String, default: 'ASSISTANT' },
   evaluationEnabled: { type: Boolean, default: true },
+  config: { type: Object, default: undefined },
 });
 const emit = defineEmits(['updateLeft', 'feedback']);
 
@@ -235,6 +236,7 @@ const streamingFetchRequest = async () => {
     body: JSON.stringify({
       question,
       ...(collectionName.length > 0 ? { collection: collectionName } : {}),
+      ...(props.config ? { config: props.config } : {}),
       mode: collectionName ? 'rag' : 'conversation',
       source_docs: collectionName ? true : false,
       streaming: true,


### PR DESCRIPTION
This PR introduces a new `config` prop to the `ChatZone` component. When provided, this configuration object is forwarded to the `/chat` endpoint as part of the request payload.

Details

- Adds `config` as an optional prop in `ChatZone`
- If `config` is present, it will be included in the request sent to `/chat`